### PR TITLE
Carthage support

### DIFF
--- a/Spreedly.xcodeproj/xcshareddata/xcschemes/Spreedly.xcscheme
+++ b/Spreedly.xcodeproj/xcshareddata/xcschemes/Spreedly.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0930"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "63E67F401BC6BE4B0023E846"
+               BuildableName = "Spreedly.framework"
+               BlueprintName = "Spreedly"
+               ReferencedContainer = "container:Spreedly.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "63E67F4A1BC6BE4B0023E846"
+               BuildableName = "SpreedlyTests.xctest"
+               BlueprintName = "SpreedlyTests"
+               ReferencedContainer = "container:Spreedly.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "63E67F401BC6BE4B0023E846"
+            BuildableName = "Spreedly.framework"
+            BlueprintName = "Spreedly"
+            ReferencedContainer = "container:Spreedly.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "63E67F401BC6BE4B0023E846"
+            BuildableName = "Spreedly.framework"
+            BlueprintName = "Spreedly"
+            ReferencedContainer = "container:Spreedly.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "63E67F401BC6BE4B0023E846"
+            BuildableName = "Spreedly.framework"
+            BlueprintName = "Spreedly"
+            ReferencedContainer = "container:Spreedly.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Once merged and released, the `Spreedly.framework` could be installed using [Carthage](https://github.com/Carthage/Carthage) using:

```
github "spreedly/spreedly-ios"
```

Enabling Carthage support is as easy as sharing the `Spreedly` scheme, which is what this PR does.

Fixes https://github.com/spreedly/spreedly-ios/issues/2.
